### PR TITLE
Fix build error on cargo install

### DIFF
--- a/tunnelto/Cargo.toml
+++ b/tunnelto/Cargo.toml
@@ -39,5 +39,5 @@ hyper = "0.14"
 hyper-tls = "0.5"
 http-body = "0.3.1"
 serde_urlencoded = "0.6.1"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["json"] }
 cli-table = "0.4"


### PR DESCRIPTION
Hey! Thanks for the great crate and service!

Starting on version 0.1.16, there's an error when trying to install via `cargo install tunnelto`:

```
error[E0599]: no method named `json` found for struct `reqwest::Response` in the current scope
```

The error can also be reproduced by cloning the repo and running:

```sh
cd tunnelto
cargo build
```

The fix was to enable the `json` feature on the `reqwest` dependency.